### PR TITLE
class RecExtElectrode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
   # Replace dep1 dep2 ... with your dependencies
   - conda config --add channels conda-forge
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy scipy coveralls pytest-cov
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy scipy meautility coveralls pytest-cov
   - conda activate test-environment
   - python setup.py install
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - python=3
   - numpy
-  
+  - meautility

--- a/lfpy_forward_models/__init__.py
+++ b/lfpy_forward_models/__init__.py
@@ -26,10 +26,10 @@ GNU General Public License for more details.
   * LineSourcePotential:
         Class for predicting extracellular potentials assuming
         line sourcers and point contacts
-
-:LFPy classes to be implemented:
   * RecExtElectrode:
         Class for simulations of extracellular potentials
+
+:LFPy classes to be implemented:
   * RecMEAElectrode:
         Class for simulations of in vitro (slice) extracellular
         potentials
@@ -55,4 +55,4 @@ from .version import version as __version__
 
 from .cell import CellGeometry
 from .models import LinearModel, CurrentDipoleMoment, PointSourcePotential, \
-    LineSourcePotential
+    LineSourcePotential, RecExtElectrode

--- a/lfpy_forward_models/models.py
+++ b/lfpy_forward_models/models.py
@@ -13,8 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 """
 
+import sys
+from copy import deepcopy
 import numpy as np
 from . import lfpcalc
+import MEAutility as mu
 
 
 class LinearModel(object):
@@ -389,3 +392,505 @@ class LineSourcePotential(LinearModel):
                                                   sigma=self.sigma,
                                                   r_limit=self.cell.d / 2)
         return M
+
+
+class RecExtElectrode(LinearModel):
+    """class RecExtElectrode
+
+    Main class that represents an extracellular electric recording devices such
+    as a laminar probe.
+
+    Parameters
+    ----------
+    cell : object
+        CellGeometry or similar instance.
+    sigma : float or list/ndarray of floats
+        extracellular conductivity in units of (S/m). A scalar value implies an
+        isotropic extracellular conductivity. If a length 3 list or array of
+        floats is provided, these values corresponds to an anisotropic
+        conductor with conductivities [sigma_x, sigma_y, sigma_z] accordingly.
+    probe : MEAutility MEA object or None
+        MEAutility probe object
+    x, y, z : np.ndarray
+        coordinates or arrays of coordinates in units of (um). Must be same length
+    N : None or list of lists
+        Normal vectors [x, y, z] of each circular electrode contact surface,
+        default None
+    r : float
+        radius of each contact surface, default None
+    n : int
+        if N is not None and r > 0, the number of discrete points used to
+        compute the n-point average potential on each circular contact point.
+    contact_shape : str
+        'circle'/'square' (default 'circle') defines the contact point shape
+        If 'circle' r is the radius, if 'square' r is the side length
+    method : str
+        switch between the assumption of 'linesource', 'pointsource',
+        'soma_as_point' to represent each compartment when computing
+        extracellular potentials
+    # from_file : bool
+    #    if True, load cell object from file
+    # cellfile : str
+    #    path to cell pickle
+    verbose : bool
+        Flag for verbose output, i.e., print more information
+    seedvalue : int
+        random seed when finding random position on contact with r > 0
+
+    Examples
+    --------
+    Compute extracellular potentials after simulating and storage of
+    transmembrane currents with the LFPy.Cell class:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> import LFPy
+    >>>
+    >>> cellParameters = {
+    >>>     'morphology' : 'examples/morphologies/L5_Mainen96_LFPy.hoc',  # morphology file
+    >>>     'v_init' : -65,                          # initial voltage
+    >>>     'cm' : 1.0,                             # membrane capacitance
+    >>>     'Ra' : 150,                             # axial resistivity
+    >>>     'passive' : True,                        # insert passive channels
+    >>>     'passive_parameters' : {"g_pas":1./3E4, "e_pas":-65}, # passive params
+    >>>     'dt' : 2**-4,                           # simulation time res
+    >>>     'tstart' : 0.,                        # start t of simulation
+    >>>     'tstop' : 50.,                        # end t of simulation
+    >>> }
+    >>> cell = LFPy.Cell(**cellParameters)
+    >>>
+    >>> synapseParameters = {
+    >>>     'idx' : cell.get_closest_idx(x=0, y=0, z=800), # compartment
+    >>>     'e' : 0,                                # reversal potential
+    >>>     'syntype' : 'ExpSyn',                   # synapse type
+    >>>     'tau' : 2,                              # syn. time constant
+    >>>     'weight' : 0.01,                       # syn. weight
+    >>>     'record_current' : True                 # syn. current record
+    >>> }
+    >>> synapse = LFPy.Synapse(cell, **synapseParameters)
+    >>> synapse.set_spike_times(np.array([10., 15., 20., 25.]))
+    >>>
+    >>> cell.simulate(rec_imem=True)
+    >>>
+    >>> N = np.empty((16, 3))
+    >>> for i in xrange(N.shape[0]): N[i,] = [1, 0, 0] #normal vec. of contacts
+    >>> electrodeParameters = {         #parameters for RecExtElectrode class
+    >>>     'sigma' : 0.3,              #Extracellular potential
+    >>>     'x' : np.zeros(16)+25,      #Coordinates of electrode contacts
+    >>>     'y' : np.zeros(16),
+    >>>     'z' : np.linspace(-500,1000,16),
+    >>>     'n' : 20,
+    >>>     'r' : 10,
+    >>>     'N' : N,
+    >>> }
+    >>> electrode = LFPy.RecExtElectrode(cell, **electrodeParameters)
+    >>> electrode.calc_lfp()
+    >>> plt.matshow(electrode.LFP)
+    >>> plt.colorbar()
+    >>> plt.axis('tight')
+    >>> plt.show()
+
+
+    Compute extracellular potentials during simulation (recommended):
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> import LFPy
+    >>>
+    >>> cellParameters = {
+    >>>     'morphology' : 'examples/morphologies/L5_Mainen96_LFPy.hoc',  # morphology file
+    >>>     'v_init' : -65,                          # initial voltage
+    >>>     'cm' : 1.0,                             # membrane capacitance
+    >>>     'Ra' : 150,                             # axial resistivity
+    >>>     'passive' : True,                        # insert passive channels
+    >>>     'passive_parameters' : {"g_pas":1./3E4, "e_pas":-65}, # passive params
+    >>>     'dt' : 2**-4,                           # simulation time res
+    >>>     'tstart' : 0.,                        # start t of simulation
+    >>>     'tstop' : 50.,                        # end t of simulation
+    >>> }
+    >>> cell = LFPy.Cell(**cellParameters)
+    >>>
+    >>> synapseParameters = {
+    >>>     'idx' : cell.get_closest_idx(x=0, y=0, z=800), # compartment
+    >>>     'e' : 0,                                # reversal potential
+    >>>     'syntype' : 'ExpSyn',                   # synapse type
+    >>>     'tau' : 2,                              # syn. time constant
+    >>>     'weight' : 0.01,                       # syn. weight
+    >>>     'record_current' : True                 # syn. current record
+    >>> }
+    >>> synapse = LFPy.Synapse(cell, **synapseParameters)
+    >>> synapse.set_spike_times(np.array([10., 15., 20., 25.]))
+    >>>
+    >>> N = np.empty((16, 3))
+    >>> for i in xrange(N.shape[0]): N[i,] = [1, 0, 0] #normal vec. of contacts
+    >>> electrodeParameters = {         #parameters for RecExtElectrode class
+    >>>     'sigma' : 0.3,              #Extracellular potential
+    >>>     'x' : np.zeros(16)+25,      #Coordinates of electrode contacts
+    >>>     'y' : np.zeros(16),
+    >>>     'z' : np.linspace(-500,1000,16),
+    >>>     'n' : 20,
+    >>>     'r' : 10,
+    >>>     'N' : N,
+    >>> }
+    >>> electrode = LFPy.RecExtElectrode(**electrodeParameters)
+    >>>
+    >>> cell.simulate(electrode=electrode)
+    >>>
+    >>> plt.matshow(electrode.LFP)
+    >>> plt.colorbar()
+    >>> plt.axis('tight')
+    >>> plt.show()
+
+    Use MEAutility to to handle probes
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> import MEAutility as mu
+    >>> import LFPy
+    >>>
+    >>> cellParameters = {
+    >>>     'morphology' : 'examples/morphologies/L5_Mainen96_LFPy.hoc',  # morphology file
+    >>>     'v_init' : -65,                          # initial voltage
+    >>>     'cm' : 1.0,                             # membrane capacitance
+    >>>     'Ra' : 150,                             # axial resistivity
+    >>>     'passive' : True,                        # insert passive channels
+    >>>     'passive_parameters' : {"g_pas":1./3E4, "e_pas":-65}, # passive params
+    >>>     'dt' : 2**-4,                           # simulation time res
+    >>>     'tstart' : 0.,                        # start t of simulation
+    >>>     'tstop' : 50.,                        # end t of simulation
+    >>> }
+    >>> cell = LFPy.Cell(**cellParameters)
+    >>>
+    >>> synapseParameters = {
+    >>>     'idx' : cell.get_closest_idx(x=0, y=0, z=800), # compartment
+    >>>     'e' : 0,                                # reversal potential
+    >>>     'syntype' : 'ExpSyn',                   # synapse type
+    >>>     'tau' : 2,                              # syn. time constant
+    >>>     'weight' : 0.01,                       # syn. weight
+    >>>     'record_current' : True                 # syn. current record
+    >>> }
+    >>> synapse = LFPy.Synapse(cell, **synapseParameters)
+    >>> synapse.set_spike_times(np.array([10., 15., 20., 25.]))
+    >>>
+    >>> cell.simulate(rec_imem=True)
+    >>>
+    >>> probe = mu.return_mea('Neuropixels-128')
+    >>> electrode = LFPy.RecExtElectrode(cell, probe=probe)
+    >>> electrode.calc_lfp()
+    >>> mu.plot_mea_recording(electrode.LFP, probe)
+    >>> plt.axis('tight')
+    >>> plt.show()
+
+    """
+
+    def __init__(self, cell, sigma=0.3, probe=None,
+                 x=None, y=None, z=None,
+                 N=None, r=None, n=None, contact_shape='circle',
+                 # perCellLFP=False,
+                 method='linesource',
+                 # from_file=False, cellfile=None,
+                 verbose=False,
+                 seedvalue=None, **kwargs):
+        """Initialize RecExtElectrode class"""
+        super().__init__(cell=cell)
+
+        self.sigma = sigma
+        if type(sigma) in [list, np.ndarray]:
+            self.sigma = np.array(sigma)
+            if not self.sigma.shape == (3,):
+                raise ValueError("Conductivity, sigma, should be float "
+                                 "or array of length 3: "
+                                 "[sigma_x, sigma_y, sigma_z]")
+            self.anisotropic = True
+        else:
+            self.sigma = sigma
+            self.anisotropic = False
+
+        if probe is None:
+
+            assert np.all([arg is not None] for arg in [x, y, z]), \
+                "instance requires either 'probe' or 'x', 'y', and 'z'"
+
+            if type(x) in [float, int]:
+                self.x = np.array([x])
+            else:
+                self.x = np.array(x).flatten()
+            if type(y) in [float, int]:
+                self.y = np.array([y])
+            else:
+                self.y = np.array(y).flatten()
+            if type(z) in [float, int]:
+                self.z = np.array([z])
+            else:
+                self.z = np.array(z).flatten()
+            try:
+                assert ((self.x.size == self.y.size) and
+                        (self.x.size == self.z.size))
+            except AssertionError as ae:
+                raise ae("The number of elements in [x, y, z] must be equal")
+
+            if N is not None:
+                if type(N) != np.array:
+                    try:
+                        N = np.array(N)
+                    except TypeError as te:
+                        print('Keyword argument N could not be converted to a '
+                              'numpy.ndarray of shape (n_contacts, 3)')
+                        print(sys.exc_info()[0])
+                        raise te
+                if N.shape[-1] == 3:
+                    self.N = N
+                else:
+                    self.N = N.T
+                    if N.shape[-1] != 3:
+                        raise Exception('N.shape must be (n_contacts, 1, 3)!')
+            else:
+                self.N = N
+
+            self.r = r
+            self.n = n
+
+            if contact_shape is None:
+                self.contact_shape = 'circle'
+            elif contact_shape in ['circle', 'square', 'rect']:
+                self.contact_shape = contact_shape
+            else:
+                raise ValueError('The contact_shape argument must be either: '
+                                 'None, \'circle\', \'square\', \'rect\'')
+            if self.contact_shape == 'rect':
+                assert len(np.array(self.r)) == 2, \
+                    "For 'rect' shape, 'r' indicates rectangle side length"
+
+            positions = np.array([self.x, self.y, self.z]).T
+            probe_info = {'pos': positions,
+                          'description': 'custom',
+                          'size': self.r,
+                          'shape': self.contact_shape,
+                          'type': 'wire',
+                          'center': False}  # add mea type
+            self.probe = mu.MEA(positions=positions, info=probe_info,
+                                normal=self.N, sigma=self.sigma)
+        else:
+            assert isinstance(probe, mu.core.MEA), \
+                "'probe' should be a MEAutility MEA object"
+            self.probe = deepcopy(probe)
+            self.x = probe.positions[:, 0]
+            self.y = probe.positions[:, 1]
+            self.z = probe.positions[:, 2]
+            self.N = np.array([el.normal for el in self.probe.electrodes])
+            self.r = self.probe.size
+            self.contact_shape = self.probe.shape
+            self.n = n
+
+        # self.perCellLFP = perCellLFP
+
+        self.method = method
+        self.verbose = verbose
+        self.seedvalue = seedvalue
+
+        self.kwargs = kwargs
+
+        # None-type some attributes created by the Cell class
+        self.electrodecoeff = None
+        self.circle = None
+        self.offsets = None
+
+        # if from_file:
+        #     if type(cellfile) == type(str()):
+        #        cell = tools.load(cellfile)
+        #    elif type(cellfile) == type([]):
+        #        cell = []
+        #        for fil in cellfile:
+        #            cell.append(tools.load(fil))
+        #    else:
+        #        raise ValueError('cell either string or list of strings')
+
+        # if cell is not None:
+        #     self.set_cell(cell)
+
+        if method == 'soma_as_point':
+            if self.anisotropic:
+                self.lfp_method = lfpcalc.calc_lfp_soma_as_point_anisotropic
+            else:
+                self.lfp_method = lfpcalc.calc_lfp_soma_as_point
+        elif method == 'som_as_point':
+            raise RuntimeError('The method "som_as_point" is deprecated.'
+                                     'Use "soma_as_point" instead')
+        elif method == 'linesource':
+            if self.anisotropic:
+                self.lfp_method = lfpcalc.calc_lfp_linesource_anisotropic
+            else:
+                self.lfp_method = lfpcalc.calc_lfp_linesource
+        elif method == 'pointsource':
+            if self.anisotropic:
+                self.lfp_method = lfpcalc.calc_lfp_pointsource_anisotropic
+            else:
+                self.lfp_method = lfpcalc.calc_lfp_pointsource
+        else:
+            raise ValueError("LFP method not recognized. "
+                             "Should be 'soma_as_point', 'linesource' "
+                             "or 'pointsource'")
+
+    '''
+    def set_cell(self, cell):
+        """Set the supplied cell object as attribute "cell" of the
+        RecExtElectrode object
+
+        Parameters
+        ----------
+        cell : obj
+            `LFPy.Cell` or `LFPy.TemplateCell` instance.
+
+        Returns
+        -------
+        None
+        """
+        self.cell = cell
+        if self.cell is not None:
+            self.r_limit = self.cell.diam/2
+            self.mapping = np.zeros((self.x.size, len(cell.xmid)))
+        '''
+
+    '''
+    def _test_imem_sum(self, tolerance=1E-8):
+        """Test that the membrane currents sum to zero"""
+        if type(self.cell) == dict or type(self.cell) == list:
+            raise DeprecationWarning('no support for more than one cell-object')
+
+        sum_imem = self.cell.imem.sum(axis=0)
+        #check if eye matrix is supplied:
+        if ((self.cell.imem.shape == (self.cell.totnsegs, self.cell.totnsegs))
+            and (np.all(self.cell.imem == np.eye(self.cell.totnsegs)))):
+            pass
+        else:
+            if abs(sum_imem).max() >= tolerance:
+                warnings.warn('Membrane currents do not sum to zero')
+                [inds] = np.where((abs(sum_imem) >= tolerance))
+                if self.cell.verbose:
+                    for i in inds:
+                        print('membrane current sum of celltimestep %i: %.3e'
+                            % (i, sum_imem[i]))
+            else:
+                pass
+     '''
+
+    def get_response_matrix(self):
+        '''
+        Get linear response matrix
+
+        Returns
+        -------
+        response_matrix: ndarray
+            shape (n_coords, n_seg) ndarray
+        '''
+        # if cell is not None:
+        #    self.set_cell(cell)
+
+        if self.n is not None and self.N is not None and self.r is not None:
+            if self.n <= 1:
+                raise ValueError("n = %i must be larger that 1" % self.n)
+            else:
+                pass
+
+            M = self._lfp_el_pos_calc_dist()
+
+            if self.verbose:
+                print('calculations finished, %s, %s' % (str(self),
+                                                         str(self.cell)))
+        else:
+            M = self._loop_over_contacts()
+            if self.verbose:
+                print('calculations finished, %s, %s' % (str(self),
+                                                         str(self.cell)))
+        # return mapping
+        return M
+
+    '''
+    def calc_lfp(self, t_indices=None, cell=None):
+        """Calculate LFP on electrode geometry from all cell instances.
+        Will chose distributed calculated if electrode contain 'n', 'N', and 'r'
+
+        Parameters
+        ----------
+        cell : obj, optional
+            `LFPy.Cell` or `LFPy.TemplateCell` instance. Must be specified here
+            if it was not specified at the initiation of the `RecExtElectrode`
+            class
+        t_indices : np.ndarray
+            Array of timestep indexes where extracellular potential should
+            be calculated.
+        """
+
+        self.calc_mapping(cell)
+
+        if t_indices is not None:
+            currmem = self.cell.imem[:, t_indices]
+        else:
+            currmem = self.cell.imem
+
+        self._test_imem_sum()
+        self.LFP = np.dot(self.mapping, currmem)
+        # del self.mapping
+    '''
+
+    def _loop_over_contacts(self, **kwargs):
+        """Loop over electrode contacts, and return LFPs across channels"""
+        M = np.zeros((self.x.size, self.cell.x.shape[0]))
+        for i in range(self.x.size):
+            M[i, :] = self.lfp_method(self.cell,
+                                      x=self.x[i],
+                                      y=self.y[i],
+                                      z=self.z[i],
+                                      sigma=self.sigma,
+                                      r_limit=self.cell.d / 2,
+                                      **kwargs)
+        return M
+
+    def _lfp_el_pos_calc_dist(self, **kwargs):
+
+        """
+        Calc. of LFP over an n-point integral approximation over flat
+        electrode surface: circle of radius r or square of side r. The
+        locations of these n points on the electrode surface are random,
+        within the given surface. """
+
+        def loop_over_points(points):
+
+            # loop over points on contact
+            lfp_e = 0
+            for j in range(self.n):
+                tmp = self.lfp_method(self.cell,
+                                      x=points[j, 0],
+                                      y=points[j, 1],
+                                      z=points[j, 2],
+                                      r_limit=self.cell.d / 2,
+                                      sigma=self.sigma,
+                                      **kwargs
+                                      )
+
+                lfp_e += tmp
+                # no longer needed
+                del tmp
+
+            return lfp_e / self.n
+
+        # linear response matrix
+        M = np.zeros((self.x.size, self.cell.x.shape[0]))
+
+        # extract random points for each electrode
+        if self.n > 1:
+            points = self.probe.get_random_points_inside(self.n)
+            for i, p in enumerate(points):
+                # fill in with contact average
+                M[i, ] = loop_over_points(p)
+            self.recorded_points = points
+        else:
+            for i, (x, y, z) in enumerate(zip(self.x, self.y, self.z)):
+                M[i, ] = self.lfp_method(self.cell,
+                                         x=x,
+                                         y=y,
+                                         z=z,
+                                         r_limit=self.cell.d / 2,
+                                         sigma=self.sigma,
+                                         **kwargs)
+            self.recorded_points = np.array([self.x, self.y, self.z]).T

--- a/lfpy_forward_models/models.py
+++ b/lfpy_forward_models/models.py
@@ -37,6 +37,7 @@ class LinearModel(object):
     cell: object
         CellGeometry or similar instance.
     '''
+
     def __init__(self, cell):
         self.cell = cell
 
@@ -98,6 +99,7 @@ class CurrentDipoleMoment(LinearModel):
            [ 0.,  0.],
            [ 2., -2.]])
     '''
+
     def __init__(self, cell):
         super().__init__(cell=cell)
 
@@ -202,14 +204,15 @@ class PointSourcePotential(LinearModel):
             Signals With LFPy 2.0. Front. Neuroinform. 12:92.
             doi: 10.3389/fninf.2018.00092
     '''
+
     def __init__(self, cell, x, y, z, sigma=0.3):
         super().__init__(cell=cell)
 
         # check input
         try:
-            assert(np.all([type(x) is np.ndarray,
-                           type(y) is np.ndarray,
-                           type(z) is np.ndarray]))
+            assert(np.all([isinstance(x, np.ndarray),
+                           isinstance(y, np.ndarray),
+                           isinstance(z, np.ndarray)]))
         except AssertionError as ae:
             raise ae('x, y and z must be of type numpy.ndarray')
         try:
@@ -221,7 +224,7 @@ class PointSourcePotential(LinearModel):
         except AssertionError as ae:
             raise ae('x, y and z must contain the same number of elements')
         try:
-            assert(type(sigma) is float and sigma > 0)
+            assert(isinstance(sigma, float) and sigma > 0)
         except AssertionError as ae:
             raise ae('sigma must be a float number greater than zero')
 
@@ -345,14 +348,15 @@ class LineSourcePotential(LinearModel):
             Signals With LFPy 2.0. Front. Neuroinform. 12:92.
             doi: 10.3389/fninf.2018.00092
     '''
+
     def __init__(self, cell, x, y, z, sigma=0.3):
         super().__init__(cell=cell)
 
         # check input
         try:
-            assert(np.all([type(x) is np.ndarray,
-                           type(y) is np.ndarray,
-                           type(z) is np.ndarray]))
+            assert(np.all([isinstance(x, np.ndarray),
+                           isinstance(y, np.ndarray),
+                           isinstance(z, np.ndarray)]))
         except AssertionError as ae:
             raise ae('x, y and z must be of type numpy.ndarray')
         try:
@@ -364,7 +368,7 @@ class LineSourcePotential(LinearModel):
         except AssertionError as ae:
             raise ae('x, y and z must contain the same number of elements')
         try:
-            assert(type(sigma) is float and sigma > 0)
+            assert(isinstance(sigma, float) and sigma > 0)
         except AssertionError as ae:
             raise ae('sigma must be a float number greater than zero')
 
@@ -426,7 +430,7 @@ class RecExtElectrode(LinearModel):
         If 'circle' r is the radius, if 'square' r is the side length
     method : str
         switch between the assumption of 'linesource', 'pointsource',
-        'soma_as_point' to represent each compartment when computing
+        'root_as_point' to represent each compartment when computing
         extracellular potentials
     verbose : bool
         Flag for verbose output, i.e., print more information
@@ -577,6 +581,7 @@ class RecExtElectrode(LinearModel):
     >>> plt.axis('tight')
     >>> plt.show()
     """
+
     def __init__(self, cell, sigma=0.3, probe=None,
                  x=None, y=None, z=None,
                  N=None, r=None, n=None, contact_shape='circle',
@@ -622,7 +627,7 @@ class RecExtElectrode(LinearModel):
                 raise ae("The number of elements in [x, y, z] must be equal")
 
             if N is not None:
-                if type(N) != np.array:
+                if not isinstance(N, np.array):
                     try:
                         N = np.array(N)
                     except TypeError as te:
@@ -685,14 +690,11 @@ class RecExtElectrode(LinearModel):
         self.circle = None
         self.offsets = None
 
-        if method == 'soma_as_point':
+        if method == 'root_as_point':
             if self.anisotropic:
-                self.lfp_method = lfpcalc.calc_lfp_soma_as_point_anisotropic
+                self.lfp_method = lfpcalc.calc_lfp_root_as_point_anisotropic
             else:
-                self.lfp_method = lfpcalc.calc_lfp_soma_as_point
-        elif method == 'som_as_point':
-            raise RuntimeError('The method "som_as_point" is deprecated.'
-                                     'Use "soma_as_point" instead')
+                self.lfp_method = lfpcalc.calc_lfp_root_as_point
         elif method == 'linesource':
             if self.anisotropic:
                 self.lfp_method = lfpcalc.calc_lfp_linesource_anisotropic
@@ -705,7 +707,7 @@ class RecExtElectrode(LinearModel):
                 self.lfp_method = lfpcalc.calc_lfp_pointsource
         else:
             raise ValueError("LFP method not recognized. "
-                             "Should be 'soma_as_point', 'linesource' "
+                             "Should be 'root_as_point', 'linesource' "
                              "or 'pointsource'")
 
     def get_response_matrix(self):
@@ -735,7 +737,6 @@ class RecExtElectrode(LinearModel):
                                                          str(self.cell)))
         # return mapping
         return M
-
 
     def _loop_over_contacts(self, **kwargs):
         """Loop over electrode contacts, and return LFPs across channels"""

--- a/lfpy_forward_models/models.py
+++ b/lfpy_forward_models/models.py
@@ -448,12 +448,13 @@ class RecExtElectrode(LinearModel):
     >>>
     >>> cellParameters = {
     >>>     'morphology' : 'examples/morphologies/L5_Mainen96_LFPy.hoc',
-    >>>     'v_init' : -65,                          # initial voltage
+    >>>     'v_init' : -65,                         # initial voltage
     >>>     'cm' : 1.0,                             # membrane capacitance
     >>>     'Ra' : 150,                             # axial resistivity
-    >>>     'passive' : True,                        # insert passive channels
-    >>>     'passive_parameters' : {"g_pas":1./3E4, "e_pas":-65}, # passive params
-    >>>     'dt' : 2**-4,                           # simulation time res
+    >>>     'passive' : True,                       # insert passive channels
+    >>>     'passive_parameters' : {"g_pas":1./3E4,
+                                    "e_pas":-65}, # passive params
+    >>>     'dt' : 2**-4,                         # simulation time res
     >>>     'tstart' : 0.,                        # start t of simulation
     >>>     'tstop' : 50.,                        # end t of simulation
     >>> }
@@ -464,7 +465,7 @@ class RecExtElectrode(LinearModel):
     >>>     'e' : 0,                                # reversal potential
     >>>     'syntype' : 'ExpSyn',                   # synapse type
     >>>     'tau' : 2,                              # syn. time constant
-    >>>     'weight' : 0.01,                       # syn. weight
+    >>>     'weight' : 0.01,                        # syn. weight
     >>>     'record_current' : True                 # syn. current record
     >>> }
     >>> synapse = LFPy.Synapse(cell, **synapseParameters)
@@ -473,10 +474,10 @@ class RecExtElectrode(LinearModel):
     >>> cell.simulate(rec_imem=True)
     >>>
     >>> N = np.empty((16, 3))
-    >>> for i in xrange(N.shape[0]): N[i,] = [1, 0, 0] #normal vec. of contacts
-    >>> electrodeParameters = {         #parameters for RecExtElectrode class
-    >>>     'sigma' : 0.3,              #Extracellular potential
-    >>>     'x' : np.zeros(16)+25,      #Coordinates of electrode contacts
+    >>> for i in xrange(N.shape[0]): N[i,] = [1, 0, 0] # normal vectors
+    >>> electrodeParameters = {         # parameters for RecExtElectrode class
+    >>>     'sigma' : 0.3,              # Extracellular potential
+    >>>     'x' : np.zeros(16)+25,      # Coordinates of electrode contacts
     >>>     'y' : np.zeros(16),
     >>>     'z' : np.linspace(-500,1000,16),
     >>>     'n' : 20,
@@ -499,12 +500,13 @@ class RecExtElectrode(LinearModel):
     >>>
     >>> cellParameters = {
     >>>     'morphology' : 'examples/morphologies/L5_Mainen96_LFPy.hoc',
-    >>>     'v_init' : -65,                          # initial voltage
+    >>>     'v_init' : -65,                         # initial voltage
     >>>     'cm' : 1.0,                             # membrane capacitance
     >>>     'Ra' : 150,                             # axial resistivity
-    >>>     'passive' : True,                        # insert passive channels
-    >>>     'passive_parameters' : {"g_pas":1./3E4, "e_pas":-65}, # passive params
-    >>>     'dt' : 2**-4,                           # simulation time res
+    >>>     'passive' : True,                       # insert passive channels
+    >>>     'passive_parameters' : {"g_pas":1./3E4,
+                                    "e_pas":-65}, # passive params
+    >>>     'dt' : 2**-4,                         # simulation time res
     >>>     'tstart' : 0.,                        # start t of simulation
     >>>     'tstop' : 50.,                        # end t of simulation
     >>> }
@@ -515,7 +517,7 @@ class RecExtElectrode(LinearModel):
     >>>     'e' : 0,                                # reversal potential
     >>>     'syntype' : 'ExpSyn',                   # synapse type
     >>>     'tau' : 2,                              # syn. time constant
-    >>>     'weight' : 0.01,                       # syn. weight
+    >>>     'weight' : 0.01,                        # syn. weight
     >>>     'record_current' : True                 # syn. current record
     >>> }
     >>> synapse = LFPy.Synapse(cell, **synapseParameters)
@@ -523,9 +525,9 @@ class RecExtElectrode(LinearModel):
     >>>
     >>> N = np.empty((16, 3))
     >>> for i in xrange(N.shape[0]): N[i,] = [1, 0, 0] #normal vec. of contacts
-    >>> electrodeParameters = {         #parameters for RecExtElectrode class
-    >>>     'sigma' : 0.3,              #Extracellular potential
-    >>>     'x' : np.zeros(16)+25,      #Coordinates of electrode contacts
+    >>> electrodeParameters = {         # parameters for RecExtElectrode class
+    >>>     'sigma' : 0.3,              # Extracellular potential
+    >>>     'x' : np.zeros(16)+25,      # Coordinates of electrode contacts
     >>>     'y' : np.zeros(16),
     >>>     'z' : np.linspace(-500,1000,16),
     >>>     'n' : 20,
@@ -550,12 +552,13 @@ class RecExtElectrode(LinearModel):
     >>>
     >>> cellParameters = {
     >>>     'morphology' : 'examples/morphologies/L5_Mainen96_LFPy.hoc',
-    >>>     'v_init' : -65,                          # initial voltage
+    >>>     'v_init' : -65,                         # initial voltage
     >>>     'cm' : 1.0,                             # membrane capacitance
     >>>     'Ra' : 150,                             # axial resistivity
-    >>>     'passive' : True,                        # insert passive channels
-    >>>     'passive_parameters' : {"g_pas":1./3E4, "e_pas":-65}, # passive params
-    >>>     'dt' : 2**-4,                           # simulation time res
+    >>>     'passive' : True,                       # insert passive channels
+    >>>     'passive_parameters' : {"g_pas":1./3E4,
+                                    "e_pas":-65}, # passive params
+    >>>     'dt' : 2**-4,                         # simulation time res
     >>>     'tstart' : 0.,                        # start t of simulation
     >>>     'tstop' : 50.,                        # end t of simulation
     >>> }
@@ -566,7 +569,7 @@ class RecExtElectrode(LinearModel):
     >>>     'e' : 0,                                # reversal potential
     >>>     'syntype' : 'ExpSyn',                   # synapse type
     >>>     'tau' : 2,                              # syn. time constant
-    >>>     'weight' : 0.01,                       # syn. weight
+    >>>     'weight' : 0.01,                        # syn. weight
     >>>     'record_current' : True                 # syn. current record
     >>> }
     >>> synapse = LFPy.Synapse(cell, **synapseParameters)

--- a/lfpy_forward_models/tests/test_lfpcalc.py
+++ b/lfpy_forward_models/tests/test_lfpcalc.py
@@ -180,11 +180,11 @@ class testLfpCalc(unittest.TestCase):
         steps = 20
         cell = DummyCell()
 
-        in_vivo = lfpcalc.calc_lfp_soma_as_point(cell,
+        in_vivo = lfpcalc.calc_lfp_root_as_point(cell,
                                                  x=0.0, y=0, z=0,
                                                  sigma=sigma_T,
                                                  r_limit=cell.d / 2)
-        in_vitro = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        in_vitro = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                       x=0.0, y=0, z=0,
                                                       sigma_T=sigma_T,
                                                       sigma_G=sigma_G,
@@ -263,7 +263,7 @@ class testLfpCalc(unittest.TestCase):
 
         np.testing.assert_almost_equal(2 * in_vivo, in_vitro, decimal=9)
 
-    def test_lfpcalc_calc_lfp_soma_as_point_moi_doubling(self):
+    def test_lfpcalc_calc_lfp_root_as_point_moi_doubling(self):
         """
         Test that slice with zero conductivity in MEA region (z<0) has twice
         the potential as in vivo case at MEA electrode plane
@@ -276,11 +276,11 @@ class testLfpCalc(unittest.TestCase):
 
         cell = DummyCell(z=np.array([[50, 50]]))
 
-        in_vivo = lfpcalc.calc_lfp_soma_as_point(cell,
+        in_vivo = lfpcalc.calc_lfp_root_as_point(cell,
                                                  x=50., y=0, z=0,
                                                  sigma=sigma_T,
                                                  r_limit=cell.d / 2)
-        in_vitro = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        in_vitro = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                       x=50, y=0, z=0,
                                                       sigma_T=sigma_T,
                                                       sigma_G=sigma_G,
@@ -355,7 +355,7 @@ class testLfpCalc(unittest.TestCase):
 
         np.testing.assert_array_less(with_saline, without_saline)
 
-    def test_lfpcalc_calc_lfp_soma_as_point_moi_saline_effect(self):
+    def test_lfpcalc_calc_lfp_root_as_point_moi_saline_effect(self):
         """
         Test that the saline bath decreases signal as expected
         """
@@ -367,7 +367,7 @@ class testLfpCalc(unittest.TestCase):
 
         cell = DummyCell(z=np.array([[100, 100]]))
 
-        with_saline = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        with_saline = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                          x=0, y=0, z=0,
                                                          sigma_T=sigma_T,
                                                          sigma_G=sigma_G,
@@ -376,7 +376,7 @@ class testLfpCalc(unittest.TestCase):
                                                          h=h,
                                                          steps=steps)
 
-        without_saline = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        without_saline = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                             x=0, y=0, z=0,
                                                             sigma_T=sigma_T,
                                                             sigma_G=sigma_G,
@@ -440,9 +440,9 @@ class testLfpCalc(unittest.TestCase):
 
         np.testing.assert_almost_equal(correct, calculated, 5)
 
-    def test_lfpcalc_calc_lfp_soma_as_point_moi_20steps(self):
+    def test_lfpcalc_calc_lfp_root_as_point_moi_20steps(self):
         """
-        Test that the calc_lfp_soma_as_point_moi reproduces previously known
+        Test that the calc_lfp_root_as_point_moi reproduces previously known
         nummerical value
         """
         sigma_T = 0.3
@@ -457,7 +457,7 @@ class testLfpCalc(unittest.TestCase):
                          y=np.array([[0., 0.]]),
                          z=np.array([[0, 220]]))
 
-        calculated = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        calculated = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                         x=100, y=0, z=0,
                                                         sigma_T=sigma_T,
                                                         sigma_G=sigma_G,
@@ -532,7 +532,7 @@ class testLfpCalc(unittest.TestCase):
 
         np.testing.assert_almost_equal(with_saline, without_saline)
 
-    def test_lfpcalc_calc_lfp_soma_as_point_moi_infinite_slice(self):
+    def test_lfpcalc_calc_lfp_root_as_point_moi_infinite_slice(self):
         """
         Test that infinitely thick slice does not affect potential.
         """
@@ -544,7 +544,7 @@ class testLfpCalc(unittest.TestCase):
 
         cell = DummyCell(z=np.array([[100, 100]]))
 
-        with_saline = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        with_saline = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                          x=0, y=0, z=0,
                                                          sigma_T=sigma_T,
                                                          sigma_G=sigma_G,
@@ -553,7 +553,7 @@ class testLfpCalc(unittest.TestCase):
                                                          h=h,
                                                          steps=steps)
 
-        without_saline = lfpcalc.calc_lfp_soma_as_point_moi(cell,
+        without_saline = lfpcalc.calc_lfp_root_as_point_moi(cell,
                                                             x=0, y=0, z=0,
                                                             sigma_T=sigma_T,
                                                             sigma_G=sigma_G,

--- a/lfpy_forward_models/tests/test_lfpcalc.py
+++ b/lfpy_forward_models/tests/test_lfpcalc.py
@@ -593,10 +593,10 @@ class DummyCell(CellGeometry):
     """CellGeometry like object with attributes for predicting extracellular
     potentials, but with:
         - 1 compartment
-        - position in (0.5,0,0)
-        - length 1
-        - diam 1
-        - current amplitude 1
+        - position in (0.5,0,0) [um]
+        - length 1 [um]
+        - diam 1 [um]
+        - current amplitude 1 [nA]
         - 1 timestep
     """
 
@@ -609,9 +609,3 @@ class DummyCell(CellGeometry):
 
         # set Attributes
         self.imem = np.array([[1.]])
-
-    def get_idx(self, section="soma"):
-        if section == "soma":
-            return np.array([0])
-        else:
-            return np.array([])

--- a/lfpy_forward_models/tests/test_module.py
+++ b/lfpy_forward_models/tests/test_module.py
@@ -326,3 +326,30 @@ class TestSuite(unittest.TestCase):
         V_gt = np.array([[0., 1., -1.]])
 
         np.testing.assert_allclose(V_ex, V_gt)
+
+    def test_RecExtElectrode_03(self):
+        """test RecExcElectrode implementation,
+        method='pointsource' with anisotropy"""
+        cell = get_cell(n_seg=1)
+        cell.x = np.array([[0., 2.4]])
+        cell.y = np.array([[0., 2.4]])
+        cell.z = np.array([[0., 2.4]])
+
+        sigma = [0.6, 0.3, 0.45]
+        r = np.array([[0.], [0.], [0.]])
+        el = lfp.RecExtElectrode(cell=cell,
+                                 x=r[0], y=r[1], z=r[2],
+                                 sigma=sigma,
+                                 method='pointsource')
+        M = el.get_response_matrix()
+
+        imem = np.array([[0., 1., -1.]])
+
+        V_ex = M @ imem
+
+        sigma_r = np.sqrt(sigma[1] * sigma[2] * 1.2**2
+                          + sigma[0] * sigma[2] * 1.2**2
+                          + sigma[0] * sigma[1] * 1.2**2)
+        V_gt = np.array([[0., 1., -1.]]) / (4 * np.pi * sigma_r)
+
+        np.testing.assert_allclose(V_ex, V_gt)

--- a/lfpy_forward_models/tests/test_module.py
+++ b/lfpy_forward_models/tests/test_module.py
@@ -116,6 +116,27 @@ class TestSuite(unittest.TestCase):
 
         np.testing.assert_allclose(V_ex, V_gt)
 
+    def test_PointSoucePotential_02(self):
+        '''test PointSourcePotential implementation, when contact is at
+        d/2 distance to segment'''
+        cell = get_cell(n_seg=1)
+        cell.d = np.array([2.])
+        sigma = 0.3
+        r = np.array([[cell.d[0] / 2],
+                      [0.],
+                      [cell.z.mean()]])
+        psp = lfp.PointSourcePotential(cell=cell, x=r[0], y=r[1, ], z=r[2, ],
+                                       sigma=sigma)
+        M = psp.get_response_matrix()
+
+        imem = np.array([[0., 1., -1.]]) * (4 * np.pi * sigma * cell.d[0] / 2)
+
+        V_ex = M @ imem
+
+        V_gt = np.array([[0., 1., -1.]])
+
+        np.testing.assert_allclose(V_ex, V_gt)
+
     def test_LineSourcePotential_00(self):
         '''test LineSourcePotential implementation'''
         cell = get_cell(n_seg=1)
@@ -228,5 +249,80 @@ class TestSuite(unittest.TestCase):
         V_gt = imem / (4 * np.pi * lsp.sigma * Deltas_n) * np.log(
             (np.sqrt(l_n**2 + r_n**2) + l_n)
             / (np.sqrt(h_n**2 + r_n**2) + h_n))
+
+        np.testing.assert_allclose(V_ex, V_gt)
+
+    def test_RecExtElectrode_00(self):
+        """test RecExcElectrode implementation,
+        method='pointsource'"""
+        cell = get_cell(n_seg=1)
+        sigma = 0.3
+        r = np.array([[cell.d[0]],
+                      [0.],
+                      [cell.z.mean()]])
+        el = lfp.RecExtElectrode(cell=cell,
+                                 x=r[0], y=r[1, ], z=r[2, ],
+                                 sigma=sigma,
+                                 method='pointsource')
+        M = el.get_response_matrix()
+
+        imem = np.array([[0., 1., -1.]]) * (4 * np.pi * sigma * cell.d[0])
+
+        V_ex = M @ imem
+
+        V_gt = np.array([[0., 1., -1.]])
+
+        np.testing.assert_allclose(V_ex, V_gt)
+
+    def test_RecExtElectrode_01(self):
+        """test LineSourcePotential implementation,
+        method='linesource'"""
+        cell = get_cell(n_seg=1)
+        cell.z = cell.z * 10
+
+        el = lfp.RecExtElectrode(cell=cell,
+                                 x=np.array([2.]),
+                                 y=np.array([0.]),
+                                 z=np.array([5.]),
+                                 sigma=0.3,
+                                 method='linesource')
+        M = el.get_response_matrix()
+
+        imem = np.array([[0., 1., -1.]])
+
+        V_ex = M @ imem
+
+        Deltas_n = 10.
+        h_n = -5.
+        r_n = 2.
+        l_n = Deltas_n + h_n
+
+        # Use Eq. C.13 case II (h<0, l>0) from Gary Holt's 1998 thesis
+        V_gt = imem / (4 * np.pi * el.sigma * Deltas_n) * np.log(
+            (np.sqrt(h_n**2 + r_n**2) - h_n)
+            * (np.sqrt(l_n**2 + r_n**2) + l_n)
+            / r_n**2)
+
+        np.testing.assert_allclose(V_ex, V_gt)
+
+    def test_RecExtElectrode_02(self):
+        """test RecExcElectrode implementation,
+        method='root_as_point'"""
+        cell = get_cell(n_seg=1)
+        sigma = 0.3
+        r = np.array([[cell.d[0]],
+                      [0.],
+                      [cell.z.mean()]])
+        el = lfp.RecExtElectrode(cell=cell,
+                                 x=r[0], y=r[1, ], z=r[2, ],
+                                 sigma=sigma,
+                                 method='root_as_point')
+        M = el.get_response_matrix()
+
+        imem = np.array([[0., 1., -1.]]) * (4 * np.pi * sigma * cell.d[0])
+
+        V_ex = M @ imem
+
+        V_gt = np.array([[0., 1., -1.]])
 
         np.testing.assert_allclose(V_ex, V_gt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # pip requirements file
 numpy
+MEAutility


### PR DESCRIPTION
Port `LFPy.RecExtElectrode`. Some modifications were required:

- Removed `perCellLFP` (not even used), `from_file` and `cell_file` args. The latter seems dependent on simulator. 

- Can't be initialized without `cell=<CellGeometry>` or similar instance as input argument. 

- removed class methods `set_cell`, `_test_imem_sum`, `calc_lfp`. Renamed `get_mapping` to `get_response_matrix`

- `method='soma_as_point'` is now `method='root_as_point'`. The root of the morphology must be at segment index 0, and there can only be one root. This change was to avoid calls to `cell.get_idx`